### PR TITLE
Use hasattr() to avoid error on Python 3.6

### DIFF
--- a/vms.py
+++ b/vms.py
@@ -265,7 +265,7 @@ def do_synctime(cnx, patterns):
     console = Console()
     with console.status("[bold green]Synchronizing time on domains..."):
         for dom in domains:
-            if getattr(time, "time_ns"):
+            if hasattr(time, "time_ns"):
                 now_ns = time.time_ns()
                 now = {"seconds": int(now_ns / 10 ** 9), "nseconds": now_ns % 10 ** 9}
             else:


### PR DESCRIPTION
Fixed issue on Python 3.6 where `getattr()` is still causing the error `AttributeError: module 'time' has no attribute 'time_ns'`.